### PR TITLE
Lavkesh/network shuffle experiments

### DIFF
--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -468,6 +468,19 @@ pub trait DistributedExt: Sized {
         enabled: bool,
     ) -> Result<(), DataFusionError>;
 
+    /// Scale factor controlling when optimized shuffle partitioning is applied at a boundary.
+    /// The optimization is applied when cardinality_task_count <= partition_count * ratio.
+    fn with_distributed_optimize_shuffle_partitioning_ratio(
+        self,
+        ratio: f64,
+    ) -> Result<Self, DataFusionError>;
+
+    /// Same as [DistributedExt::with_distributed_optimize_shuffle_partitioning_ratio] but with an in-place mutation.
+    fn set_distributed_optimize_shuffle_partitioning_ratio(
+        &mut self,
+        ratio: f64,
+    ) -> Result<(), DataFusionError>;
+
     /// The compression type to use for sending data over the wire.
     ///
     /// The default is [CompressionType::LZ4_FRAME].
@@ -635,6 +648,23 @@ impl DistributedExt for SessionConfig {
         let d_cfg = DistributedConfig::from_config_options_mut(self.options_mut())?;
         d_cfg.optimize_shuffle_partitioning = enabled;
         Ok(())
+    }
+
+    fn set_distributed_optimize_shuffle_partitioning_ratio(
+        &mut self,
+        ratio: f64,
+    ) -> Result<(), DataFusionError> {
+        let d_cfg = DistributedConfig::from_config_options_mut(self.options_mut())?;
+        d_cfg.optimize_shuffle_partitioning_ratio = ratio;
+        Ok(())
+    }
+
+    fn with_distributed_optimize_shuffle_partitioning_ratio(
+        mut self,
+        ratio: f64,
+    ) -> Result<Self, DataFusionError> {
+        self.set_distributed_optimize_shuffle_partitioning_ratio(ratio)?;
+        Ok(self)
     }
 
     fn set_distributed_compression(
@@ -816,6 +846,11 @@ impl DistributedExt for SessionStateBuilder {
             #[expr($?;Ok(self))]
             fn with_distributed_optimize_shuffle_partitioning(mut self, enabled: bool) -> Result<Self, DataFusionError>;
 
+            fn set_distributed_optimize_shuffle_partitioning_ratio(&mut self, ratio: f64) -> Result<(), DataFusionError>;
+            #[call(set_distributed_optimize_shuffle_partitioning_ratio)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_optimize_shuffle_partitioning_ratio(mut self, ratio: f64) -> Result<Self, DataFusionError>;
+
             fn set_distributed_compression(&mut self, compression: Option<CompressionType>) -> Result<(), DataFusionError>;
             #[call(set_distributed_compression)]
             #[expr($?;Ok(self))]
@@ -907,6 +942,11 @@ impl DistributedExt for SessionState {
             #[expr($?;Ok(self))]
             fn with_distributed_optimize_shuffle_partitioning(mut self, enabled: bool) -> Result<Self, DataFusionError>;
 
+            fn set_distributed_optimize_shuffle_partitioning_ratio(&mut self, ratio: f64) -> Result<(), DataFusionError>;
+            #[call(set_distributed_optimize_shuffle_partitioning_ratio)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_optimize_shuffle_partitioning_ratio(mut self, ratio: f64) -> Result<Self, DataFusionError>;
+
             fn set_distributed_compression(&mut self, compression: Option<CompressionType>) -> Result<(), DataFusionError>;
             #[call(set_distributed_compression)]
             #[expr($?;Ok(self))]
@@ -997,6 +1037,11 @@ impl DistributedExt for SessionContext {
             #[call(set_distributed_optimize_shuffle_partitioning)]
             #[expr($?;Ok(self))]
             fn with_distributed_optimize_shuffle_partitioning(self, enabled: bool) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_optimize_shuffle_partitioning_ratio(&mut self, ratio: f64) -> Result<(), DataFusionError>;
+            #[call(set_distributed_optimize_shuffle_partitioning_ratio)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_optimize_shuffle_partitioning_ratio(self, ratio: f64) -> Result<Self, DataFusionError>;
 
             fn set_distributed_compression(&mut self, compression: Option<CompressionType>) -> Result<(), DataFusionError>;
             #[call(set_distributed_compression)]

--- a/src/distributed_ext.rs
+++ b/src/distributed_ext.rs
@@ -455,6 +455,19 @@ pub trait DistributedExt: Sized {
     /// Same as [DistributedExt::with_distributed_broadcast_joins_enabled] but with an in-place mutation.
     fn set_distributed_broadcast_joins(&mut self, enabled: bool) -> Result<(), DataFusionError>;
 
+    /// Enables or disables optimized shuffle partitioning (1:1 task-partition mapping).
+    /// When enabled, eliminates N×M partition inflation during network shuffles.
+    fn with_distributed_optimize_shuffle_partitioning(
+        self,
+        enabled: bool,
+    ) -> Result<Self, DataFusionError>;
+
+    /// Same as [DistributedExt::with_distributed_optimize_shuffle_partitioning] but with an in-place mutation.
+    fn set_distributed_optimize_shuffle_partitioning(
+        &mut self,
+        enabled: bool,
+    ) -> Result<(), DataFusionError>;
+
     /// The compression type to use for sending data over the wire.
     ///
     /// The default is [CompressionType::LZ4_FRAME].
@@ -615,6 +628,15 @@ impl DistributedExt for SessionConfig {
         Ok(())
     }
 
+    fn set_distributed_optimize_shuffle_partitioning(
+        &mut self,
+        enabled: bool,
+    ) -> Result<(), DataFusionError> {
+        let d_cfg = DistributedConfig::from_config_options_mut(self.options_mut())?;
+        d_cfg.optimize_shuffle_partitioning = enabled;
+        Ok(())
+    }
+
     fn set_distributed_compression(
         &mut self,
         compression: Option<CompressionType>,
@@ -703,6 +725,10 @@ impl DistributedExt for SessionConfig {
             #[expr($?;Ok(self))]
             fn with_distributed_broadcast_joins(mut self, enabled: bool) -> Result<Self, DataFusionError>;
 
+            #[call(set_distributed_optimize_shuffle_partitioning)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_optimize_shuffle_partitioning(mut self, enabled: bool) -> Result<Self, DataFusionError>;
+
             #[call(set_distributed_compression)]
             #[expr($?;Ok(self))]
             fn with_distributed_compression(mut self, compression: Option<CompressionType>) -> Result<Self, DataFusionError>;
@@ -784,6 +810,11 @@ impl DistributedExt for SessionStateBuilder {
             #[call(set_distributed_broadcast_joins)]
             #[expr($?;Ok(self))]
             fn with_distributed_broadcast_joins(mut self, enabled: bool) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_optimize_shuffle_partitioning(&mut self, enabled: bool) -> Result<(), DataFusionError>;
+            #[call(set_distributed_optimize_shuffle_partitioning)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_optimize_shuffle_partitioning(mut self, enabled: bool) -> Result<Self, DataFusionError>;
 
             fn set_distributed_compression(&mut self, compression: Option<CompressionType>) -> Result<(), DataFusionError>;
             #[call(set_distributed_compression)]
@@ -871,6 +902,11 @@ impl DistributedExt for SessionState {
             #[expr($?;Ok(self))]
             fn with_distributed_broadcast_joins(mut self, enabled: bool) -> Result<Self, DataFusionError>;
 
+            fn set_distributed_optimize_shuffle_partitioning(&mut self, enabled: bool) -> Result<(), DataFusionError>;
+            #[call(set_distributed_optimize_shuffle_partitioning)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_optimize_shuffle_partitioning(mut self, enabled: bool) -> Result<Self, DataFusionError>;
+
             fn set_distributed_compression(&mut self, compression: Option<CompressionType>) -> Result<(), DataFusionError>;
             #[call(set_distributed_compression)]
             #[expr($?;Ok(self))]
@@ -956,6 +992,11 @@ impl DistributedExt for SessionContext {
             #[call(set_distributed_broadcast_joins)]
             #[expr($?;Ok(self))]
             fn with_distributed_broadcast_joins(self, enabled: bool) -> Result<Self, DataFusionError>;
+
+            fn set_distributed_optimize_shuffle_partitioning(&mut self, enabled: bool) -> Result<(), DataFusionError>;
+            #[call(set_distributed_optimize_shuffle_partitioning)]
+            #[expr($?;Ok(self))]
+            fn with_distributed_optimize_shuffle_partitioning(self, enabled: bool) -> Result<Self, DataFusionError>;
 
             fn set_distributed_compression(&mut self, compression: Option<CompressionType>) -> Result<(), DataFusionError>;
             #[call(set_distributed_compression)]

--- a/src/distributed_planner/batch_coalescing_below_network_boundaries.rs
+++ b/src/distributed_planner/batch_coalescing_below_network_boundaries.rs
@@ -84,7 +84,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 2 ── Tasks: t0:[p0..p3] t1:[p0..p3] 
           │ AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday, WindGustDir@1 as WindGustDir], aggr=[]
-          │   [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+          │   [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3, optimized=false
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] t2:[p0..p7] 
             │ RepartitionExec: partitioning=Hash([RainToday@0, WindGustDir@1], 8), input_partitions=4
@@ -112,7 +112,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 2 ── Tasks: t0:[p0..p3] t1:[p0..p3] 
           │ AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday, WindGustDir@1 as WindGustDir], aggr=[]
-          │   [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+          │   [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3, optimized=false
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] t2:[p0..p7] 
             │ RepartitionExec: partitioning=Hash([RainToday@0, WindGustDir@1], 8), input_partitions=4
@@ -141,7 +141,7 @@ mod tests {
           ┌───── Stage 2 ── Tasks: t0:[p0..p3] t1:[p0..p3] 
           │ CoalesceBatchesExec: target_batch_size=101
           │   AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday, WindGustDir@1 as WindGustDir], aggr=[]
-          │     [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+          │     [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3, optimized=false
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] t2:[p0..p7] 
             │ CoalesceBatchesExec: target_batch_size=101

--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -47,6 +47,11 @@ extensions_options! {
         pub broadcast_joins: bool, default = false
         /// Use 1:1 task-partition mapping instead of N*M fanout, eliminating partition inflation.
         pub optimize_shuffle_partitioning: bool, default = false
+        /// Scale factor controlling when optimized shuffle partitioning is applied at a boundary.
+        /// The optimization is applied when cardinality_task_count <= partition_count * ratio.
+        /// A ratio of 1.0 (default) only optimizes when task count <= partition count exactly.
+        /// A ratio > 1.0 also optimizes when task count is slightly above partition count.
+        pub optimize_shuffle_partitioning_ratio: f64, default = 1.0
         /// The compression used for sending data over the network between workers.
         /// It can be set to either `zstd`, `lz4` or `none`.
         pub compression: String, default = "lz4".to_string()

--- a/src/distributed_planner/distributed_config.rs
+++ b/src/distributed_planner/distributed_config.rs
@@ -45,6 +45,8 @@ extensions_options! {
         /// use broadcasting like checking build side size.
         /// For now, broadcasting all CollectLeft joins is not always beneficial.
         pub broadcast_joins: bool, default = false
+        /// Use 1:1 task-partition mapping instead of N*M fanout, eliminating partition inflation.
+        pub optimize_shuffle_partitioning: bool, default = false
         /// The compression used for sending data over the network between workers.
         /// It can be set to either `zstd`, `lz4` or `none`.
         pub compression: String, default = "lz4".to_string()

--- a/src/distributed_planner/distributed_physical_optimizer_rule.rs
+++ b/src/distributed_planner/distributed_physical_optimizer_rule.rs
@@ -121,17 +121,11 @@ fn distribute_plan(
 
             let child_plan = require_one_child(new_children)?;
 
-            let downstream_task_count = if d_cfg.optimize_shuffle_partitioning {
-                child_plan.output_partitioning().partition_count()
-            } else {
-                task_count
-            };
-
             let node = Arc::new(NetworkShuffleExec::try_new(
                 child_plan,
                 query_id,
                 *stage_id,
-                downstream_task_count,
+                task_count,
                 max_child_task_count.unwrap_or(1),
                 d_cfg.optimize_shuffle_partitioning,
             )?);
@@ -247,7 +241,7 @@ mod tests {
           │ SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
           │   ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday, count(Int64(1))@1 as count(Int64(1))]
           │     AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
-          │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+          │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3, optimized=false
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] t2:[p0..p7] 
             │ RepartitionExec: partitioning=Hash([RainToday@0], 8), input_partitions=1
@@ -277,7 +271,7 @@ mod tests {
           │ SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
           │   ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday, count(Int64(1))@1 as count(Int64(1))]
           │     AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
-          │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=2
+          │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=2, optimized=false
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] 
             │ RepartitionExec: partitioning=Hash([RainToday@0], 8), input_partitions=2
@@ -327,7 +321,7 @@ mod tests {
         │     SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
         │       ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday, count(Int64(1))@1 as count(Int64(1))]
         │         AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
-        │           [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+        │           [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3, optimized=false
         └──────────────────────────────────────────────────
           ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p0..p3] t2:[p0..p3] 
           │ RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=1
@@ -380,7 +374,7 @@ mod tests {
           │ SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
           │   ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday, count(Int64(1))@1 as count(Int64(1))]
           │     AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
-          │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+          │       [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3, optimized=false
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] t2:[p0..p7] 
             │ RepartitionExec: partitioning=Hash([RainToday@0], 8), input_partitions=1
@@ -445,12 +439,12 @@ mod tests {
         │       [Stage 2] => NetworkCoalesceExec: output_partitions=8, input_tasks=2
         │     ProjectionExec: expr=[avg(weather.MaxTemp)@1 as MaxTemp, RainTomorrow@0 as RainTomorrow]
         │       AggregateExec: mode=FinalPartitioned, gby=[RainTomorrow@0 as RainTomorrow], aggr=[avg(weather.MaxTemp)]
-        │         [Stage 3] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+        │         [Stage 3] => NetworkShuffleExec: output_partitions=4, input_tasks=3, optimized=false
         └──────────────────────────────────────────────────
           ┌───── Stage 2 ── Tasks: t0:[p0..p3] t1:[p0..p3] 
           │ ProjectionExec: expr=[avg(weather.MinTemp)@1 as MinTemp, RainTomorrow@0 as RainTomorrow]
           │   AggregateExec: mode=FinalPartitioned, gby=[RainTomorrow@0 as RainTomorrow], aggr=[avg(weather.MinTemp)]
-          │     [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+          │     [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3, optimized=false
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] t2:[p0..p7] 
             │ RepartitionExec: partitioning=Hash([RainTomorrow@0], 8), input_partitions=4
@@ -509,7 +503,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 2 ── Tasks: t0:[p0..p3] t1:[p0..p3] 
           │ AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday, WindGustDir@1 as WindGustDir], aggr=[]
-          │   [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3
+          │   [Stage 1] => NetworkShuffleExec: output_partitions=4, input_tasks=3, optimized=false
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p7] t1:[p0..p7] t2:[p0..p7] 
             │ RepartitionExec: partitioning=Hash([RainToday@0, WindGustDir@1], 8), input_partitions=1

--- a/src/distributed_planner/distributed_physical_optimizer_rule.rs
+++ b/src/distributed_planner/distributed_physical_optimizer_rule.rs
@@ -118,12 +118,22 @@ fn distribute_plan(
             if task_count == 1 && max_child_task_count == Some(1) {
                 return require_one_child(new_children);
             }
+
+            let child_plan = require_one_child(new_children)?;
+
+            let downstream_task_count = if d_cfg.optimize_shuffle_partitioning {
+                child_plan.output_partitioning().partition_count()
+            } else {
+                task_count
+            };
+
             let node = Arc::new(NetworkShuffleExec::try_new(
-                require_one_child(new_children)?,
+                child_plan,
                 query_id,
                 *stage_id,
-                task_count,
+                downstream_task_count,
                 max_child_task_count.unwrap_or(1),
+                d_cfg.optimize_shuffle_partitioning,
             )?);
             stage_id.add_assign(1);
             Ok(node)
@@ -962,5 +972,98 @@ mod tests {
         } else {
             format!("{}", displayable(physical_plan.as_ref()).indent(true))
         }
+    }
+
+    async fn sql_to_explain_optimized(
+        query: &str,
+        num_workers: usize,
+    ) -> String {
+        use crate::test_utils::plans::base_session_builder_with_shuffle_optimization;
+
+        let target_partitions = 4;
+        let mut builder = base_session_builder_with_shuffle_optimization(
+            target_partitions,
+            num_workers,
+            false,
+            true,
+        );
+
+        builder = builder.with_physical_optimizer_rule(Arc::new(DistributedPhysicalOptimizerRule));
+
+        let (ctx, query) = context_with_query(builder, query).await;
+        let df = ctx.sql(&query).await.unwrap();
+        let physical_plan = df.create_physical_plan().await.unwrap();
+
+        display_plan_ascii(physical_plan.as_ref(), false)
+    }
+
+    #[tokio::test]
+    async fn test_aggregation_optimized() {
+        let query = r#"
+        SELECT count(*), "RainToday" FROM weather GROUP BY "RainToday" ORDER BY count(*)
+        "#;
+        let plan = sql_to_explain_optimized(query, 3).await;
+        assert_snapshot!(plan, @r"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ ProjectionExec: expr=[count(*)@0 as count(*), RainToday@1 as RainToday]
+        │   SortPreservingMergeExec: [count(Int64(1))@2 ASC NULLS LAST]
+        │     [Stage 2] => NetworkCoalesceExec: output_partitions=4, input_tasks=4
+        └──────────────────────────────────────────────────
+          ┌───── Stage 2 ── Tasks: t0:[p0] t1:[p1] t2:[p2] t3:[p3]
+          │ SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
+          │   ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday, count(Int64(1))@1 as count(Int64(1))]
+          │     AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+          │       [Stage 1] => NetworkShuffleExec: output_partitions=1, input_tasks=3
+          └──────────────────────────────────────────────────
+            ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p0..p3] t2:[p0..p3]
+            │ RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=1
+            │   AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
+            │     PartitionIsolatorExec: t0:[p0,__,__] t1:[__,p0,__] t2:[__,__,p0]
+            │       DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[RainToday], file_type=parquet
+            └──────────────────────────────────────────────────
+        ");
+    }
+
+    #[tokio::test]
+    async fn test_distinct_optimized() {
+        let query = r#"
+        SELECT DISTINCT "RainToday", "WindGustDir" FROM weather
+        "#;
+        let plan = sql_to_explain_optimized(query, 3).await;
+        assert_snapshot!(plan, @r"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ CoalescePartitionsExec
+        │   [Stage 2] => NetworkCoalesceExec: output_partitions=4, input_tasks=4
+        └──────────────────────────────────────────────────
+          ┌───── Stage 2 ── Tasks: t0:[p0] t1:[p1] t2:[p2] t3:[p3]
+          │ AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday, WindGustDir@1 as WindGustDir], aggr=[]
+          │   [Stage 1] => NetworkShuffleExec: output_partitions=1, input_tasks=3
+          └──────────────────────────────────────────────────
+            ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p0..p3] t2:[p0..p3]
+            │ RepartitionExec: partitioning=Hash([RainToday@0, WindGustDir@1], 4), input_partitions=1
+            │   AggregateExec: mode=Partial, gby=[RainToday@0 as RainToday, WindGustDir@1 as WindGustDir], aggr=[]
+            │     PartitionIsolatorExec: t0:[p0,__,__] t1:[__,p0,__] t2:[__,__,p0]
+            │       DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[RainToday, WindGustDir], file_type=parquet
+            └──────────────────────────────────────────────────
+        ");
+    }
+
+    #[tokio::test]
+    async fn test_sort_optimized() {
+        let query = r#"
+        SELECT * FROM weather ORDER BY "MinTemp" DESC
+        "#;
+        let plan = sql_to_explain_optimized(query, 3).await;
+        assert_snapshot!(plan, @r"
+        ┌───── DistributedExec ── Tasks: t0:[p0]
+        │ SortPreservingMergeExec: [MinTemp@0 DESC]
+        │   [Stage 1] => NetworkCoalesceExec: output_partitions=3, input_tasks=3
+        └──────────────────────────────────────────────────
+          ┌───── Stage 1 ── Tasks: t0:[p0] t1:[p1] t2:[p2]
+          │ SortExec: expr=[MinTemp@0 DESC], preserve_partitioning=[true]
+          │   PartitionIsolatorExec: t0:[p0,__,__] t1:[__,p0,__] t2:[__,__,p0]
+          │     DataSourceExec: file_groups={3 groups: [[/testdata/weather/result-000000.parquet], [/testdata/weather/result-000001.parquet], [/testdata/weather/result-000002.parquet]]}, projection=[MinTemp, MaxTemp, Rainfall, Evaporation, Sunshine, WindGustDir, WindGustSpeed, WindDir9am, WindDir3pm, WindSpeed9am, WindSpeed3pm, Humidity9am, Humidity3pm, Pressure9am, Pressure3pm, Cloud9am, Cloud3pm, Temp9am, Temp3pm, RainToday, RISK_MM, RainTomorrow], file_type=parquet
+          └──────────────────────────────────────────────────
+        ");
     }
 }

--- a/src/distributed_planner/distributed_physical_optimizer_rule.rs
+++ b/src/distributed_planner/distributed_physical_optimizer_rule.rs
@@ -121,13 +121,20 @@ fn distribute_plan(
 
             let child_plan = require_one_child(new_children)?;
 
+            // Only use optimized shuffle when the annotated task_count matches the upstream
+            // partition count exactly — meaning the annotator determined the optimization was
+            // beneficial (cardinality estimate <= partition count). Otherwise fall back to
+            // non-optimized to preserve downstream parallelism.
+            let use_optimized = d_cfg.optimize_shuffle_partitioning
+                && task_count == child_plan.output_partitioning().partition_count();
+
             let node = Arc::new(NetworkShuffleExec::try_new(
                 child_plan,
                 query_id,
                 *stage_id,
                 task_count,
                 max_child_task_count.unwrap_or(1),
-                d_cfg.optimize_shuffle_partitioning,
+                use_optimized,
             )?);
             stage_id.add_assign(1);
             Ok(node)

--- a/src/distributed_planner/distributed_physical_optimizer_rule.rs
+++ b/src/distributed_planner/distributed_physical_optimizer_rule.rs
@@ -1013,7 +1013,7 @@ mod tests {
           │ SortExec: expr=[count(*)@0 ASC NULLS LAST], preserve_partitioning=[true]
           │   ProjectionExec: expr=[count(Int64(1))@1 as count(*), RainToday@0 as RainToday, count(Int64(1))@1 as count(Int64(1))]
           │     AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday], aggr=[count(Int64(1))]
-          │       [Stage 1] => NetworkShuffleExec: output_partitions=1, input_tasks=3
+          │       [Stage 1] => NetworkShuffleExec: output_partitions=1, input_tasks=3, optimized=true
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p0..p3] t2:[p0..p3]
             │ RepartitionExec: partitioning=Hash([RainToday@0], 4), input_partitions=1
@@ -1037,7 +1037,7 @@ mod tests {
         └──────────────────────────────────────────────────
           ┌───── Stage 2 ── Tasks: t0:[p0] t1:[p1] t2:[p2] t3:[p3]
           │ AggregateExec: mode=FinalPartitioned, gby=[RainToday@0 as RainToday, WindGustDir@1 as WindGustDir], aggr=[]
-          │   [Stage 1] => NetworkShuffleExec: output_partitions=1, input_tasks=3
+          │   [Stage 1] => NetworkShuffleExec: output_partitions=1, input_tasks=3, optimized=true
           └──────────────────────────────────────────────────
             ┌───── Stage 1 ── Tasks: t0:[p0..p3] t1:[p0..p3] t2:[p0..p3]
             │ RepartitionExec: partitioning=Hash([RainToday@0, WindGustDir@1], 4), input_partitions=1

--- a/src/distributed_planner/plan_annotator.rs
+++ b/src/distributed_planner/plan_annotator.rs
@@ -392,13 +392,19 @@ fn _annotate_plan(
         // ID to fetch from the upstream stage. This requires downstream task count == upstream
         // partition count. Override the cardinality-derived downstream task count here to enforce
         // that invariant so stage scheduling spawns the right number of tasks.
+        //
+        // Only apply when the cardinality-derived task count does not exceed the upstream partition
+        // count. If cardinality says more tasks are needed (high-volume stages), fall back to
+        // non-optimized so parallelism is preserved.
         if d_cfg.optimize_shuffle_partitioning {
             if let PlanOrNetworkBoundary::Shuffle = &annotation.plan_or_nb {
                 if let Some(PlanOrNetworkBoundary::Plan(repartition)) =
                     annotation.children.first().map(|c| &c.plan_or_nb)
                 {
                     let partition_count = repartition.output_partitioning().partition_count();
-                    annotation.task_count = Desired(partition_count);
+                    if annotation.task_count.as_usize() <= partition_count {
+                        annotation.task_count = Desired(partition_count);
+                    }
                 }
             }
         }

--- a/src/distributed_planner/plan_annotator.rs
+++ b/src/distributed_planner/plan_annotator.rs
@@ -5,6 +5,7 @@ use datafusion::common::{DataFusionError, plan_datafusion_err};
 use datafusion::config::ConfigOptions;
 use datafusion::physical_expr::Partitioning;
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::ExecutionPlanProperties;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::execution_plan::CardinalityEffect;
 use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
@@ -386,6 +387,22 @@ fn _annotate_plan(
         );
         let prev_task_count = annotation.task_count.as_usize() as f64;
         annotation.task_count = Desired((prev_task_count * sf).ceil() as usize);
+
+        // In optimized shuffle mode, NetworkShuffleExec uses task_index directly as the partition
+        // ID to fetch from the upstream stage. This requires downstream task count == upstream
+        // partition count. Override the cardinality-derived downstream task count here to enforce
+        // that invariant so stage scheduling spawns the right number of tasks.
+        if d_cfg.optimize_shuffle_partitioning {
+            if let PlanOrNetworkBoundary::Shuffle = &annotation.plan_or_nb {
+                if let Some(PlanOrNetworkBoundary::Plan(repartition)) =
+                    annotation.children.first().map(|c| &c.plan_or_nb)
+                {
+                    let partition_count = repartition.output_partitioning().partition_count();
+                    annotation.task_count = Desired(partition_count);
+                }
+            }
+        }
+
         Ok(annotation)
     } else if root {
         // If this is the root node, it means that we have just finished annotating nodes for the

--- a/src/distributed_planner/plan_annotator.rs
+++ b/src/distributed_planner/plan_annotator.rs
@@ -402,7 +402,8 @@ fn _annotate_plan(
                     annotation.children.first().map(|c| &c.plan_or_nb)
                 {
                     let partition_count = repartition.output_partitioning().partition_count();
-                    if annotation.task_count.as_usize() <= partition_count {
+                    let threshold = (partition_count as f64 * d_cfg.optimize_shuffle_partitioning_ratio).ceil() as usize;
+                    if annotation.task_count.as_usize() <= threshold {
                         annotation.task_count = Desired(partition_count);
                     }
                 }

--- a/src/distributed_planner/plan_annotator.rs
+++ b/src/distributed_planner/plan_annotator.rs
@@ -393,19 +393,32 @@ fn _annotate_plan(
         // partition count. Override the cardinality-derived downstream task count here to enforce
         // that invariant so stage scheduling spawns the right number of tasks.
         //
-        // Only apply when the cardinality-derived task count does not exceed the upstream partition
-        // count. If cardinality says more tasks are needed (high-volume stages), fall back to
-        // non-optimized so parallelism is preserved.
+        // The optimize_shuffle_partitioning_ratio scales the task count at shuffle boundaries.
+        // capped = ceil(partition_count * ratio), minimum 1.
+        // - ratio >= 1.0: clamp(cardinality, partition_count, capped)
+        //     - cardinality < p → lifted to p (optimized 1:1 mapping)
+        //     - p <= cardinality <= capped → kept as-is
+        //     - cardinality > capped → reduced to capped (between p and p*N)
+        //     - ratio=1 always produces p tasks (fully optimized)
+        // - ratio < 1.0: cardinality.min(capped) — scales down below p, no floor
         if d_cfg.optimize_shuffle_partitioning {
             if let PlanOrNetworkBoundary::Shuffle = &annotation.plan_or_nb {
                 if let Some(PlanOrNetworkBoundary::Plan(repartition)) =
                     annotation.children.first().map(|c| &c.plan_or_nb)
                 {
+                    let ratio = d_cfg.optimize_shuffle_partitioning_ratio;
                     let partition_count = repartition.output_partitioning().partition_count();
-                    let threshold = (partition_count as f64 * d_cfg.optimize_shuffle_partitioning_ratio).ceil() as usize;
-                    if annotation.task_count.as_usize() <= threshold {
-                        annotation.task_count = Desired(partition_count);
-                    }
+                    let capped = ((partition_count as f64 * ratio).ceil() as usize).max(1);
+                    let cardinality = annotation.task_count.as_usize();
+                    let new_task_count = if ratio >= 1.0 {
+                        // Clamp always applies: lifts below p, caps above capped.
+                        // ratio=1 → task_count=p (optimized). ratio>1 → between p and p*ratio.
+                        cardinality.max(partition_count).min(capped)
+                    } else {
+                        // Scale down below p. No floor — ratio=0.5 → max p/2 tasks.
+                        cardinality.min(capped)
+                    };
+                    annotation.task_count = Desired(new_task_count);
                 }
             }
         }

--- a/src/execution_plans/benchmarks/shuffle_bench.rs
+++ b/src/execution_plans/benchmarks/shuffle_bench.rs
@@ -149,6 +149,7 @@ impl ShuffleBench {
                 input_stage: input_stage.clone(),
                 worker_connections: WorkerConnectionPool::new(self.producer_tasks),
                 metrics_collection: Arc::new(Default::default()),
+                optimize_shuffle_partitioning: false,
             };
             let task_ctx = Arc::new(task_ctx_with_extension(
                 &task_ctx,

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -118,6 +118,8 @@ pub struct NetworkShuffleExec {
     /// a task to the last NetworkCoalesceExec to read from it, which may or may not be this
     /// instance.
     pub(crate) metrics_collection: Arc<DashMap<TaskKey, Vec<pb::MetricsSet>>>,
+    /// Whether to use optimized shuffle partitioning (1:1 task-partition mapping)
+    pub(crate) optimize_shuffle_partitioning: bool,
 }
 
 impl NetworkShuffleExec {
@@ -131,6 +133,7 @@ impl NetworkShuffleExec {
         num: usize,
         task_count: usize,
         input_task_count: usize,
+        optimize_shuffle_partitioning: bool,
     ) -> Result<Self, DataFusionError> {
         if !matches!(input.output_partitioning(), Partitioning::Hash(_, _)) {
             return plan_err!("NetworkShuffleExec input must be hash partitioned");
@@ -138,16 +141,19 @@ impl NetworkShuffleExec {
 
         let transformed = Arc::clone(&input).transform_down(|plan| {
             if let Some(r_exe) = plan.as_any().downcast_ref::<RepartitionExec>() {
-                // Scale the input RepartitionExec to account for all the tasks to which it will
-                // need to fan data out.
-                let scaled = Arc::new(RepartitionExec::try_new(
-                    require_one_child(r_exe.children())?,
-                    scale_partitioning(r_exe.partitioning(), |p| p * task_count),
-                )?);
+                let scaled = if optimize_shuffle_partitioning {
+                    Arc::new(RepartitionExec::try_new(
+                        require_one_child(r_exe.children())?,
+                        r_exe.partitioning().clone(),
+                    )?)
+                } else {
+                    Arc::new(RepartitionExec::try_new(
+                        require_one_child(r_exe.children())?,
+                        scale_partitioning(r_exe.partitioning(), |p| p * task_count),
+                    )?)
+                };
                 Ok(Transformed::new(scaled, true, TreeNodeRecursion::Stop))
             } else if matches!(plan.output_partitioning(), Partitioning::Hash(_, _)) {
-                // This might be a passthrough node, like a CoalesceBatchesExec or something like that.
-                // This is fine, we can let the node be here.
                 Ok(Transformed::no(plan))
             } else {
                 return plan_err!(
@@ -157,6 +163,14 @@ impl NetworkShuffleExec {
             }
         })?;
 
+        let properties = if optimize_shuffle_partitioning {
+            let mut props = input.properties().clone();
+            props.partitioning = Partitioning::UnknownPartitioning(1);
+            props
+        } else {
+            input.properties().clone()
+        };
+
         Ok(Self {
             input_stage: Stage {
                 query_id,
@@ -165,8 +179,9 @@ impl NetworkShuffleExec {
                 tasks: vec![ExecutionTask { url: None }; input_task_count],
             },
             worker_connections: WorkerConnectionPool::new(input_task_count),
-            properties: input.properties().clone(),
+            properties,
             metrics_collection: Default::default(),
+            optimize_shuffle_partitioning,
         })
     }
 }
@@ -230,19 +245,34 @@ impl ExecutionPlan for NetworkShuffleExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream, DataFusionError> {
         let task_context = DistributedTaskContext::from_ctx(&context);
-        let off = self.properties.partitioning.partition_count() * task_context.task_index;
+
+        let (partition_offset, partition_range) = if self.optimize_shuffle_partitioning {
+            let partition_id = task_context.task_index;
+            (partition_id, partition_id..(partition_id + 1))
+        } else {
+            let partition_count = self.properties.partitioning.partition_count();
+            let off = partition_count * task_context.task_index;
+            (off, off..(off + partition_count))
+        };
 
         let mut streams = Vec::with_capacity(self.input_stage.tasks.len());
         for input_task_index in 0..self.input_stage.tasks.len() {
             let worker_connection = self.worker_connections.get_or_init_worker_connection(
                 &self.input_stage,
-                off..(off + self.properties.partitioning.partition_count()),
+                partition_range.clone(),
                 input_task_index,
                 &context,
             )?;
 
             let metrics_collection = Arc::clone(&self.metrics_collection);
-            let stream = worker_connection.stream_partition(off + partition, move |meta| {
+
+            let actual_partition = if self.optimize_shuffle_partitioning {
+                partition_offset
+            } else {
+                partition_offset + partition
+            };
+
+            let stream = worker_connection.stream_partition(actual_partition, move |meta| {
                 if let Some(flight_app_metadata::Content::MetricsCollection(m)) = meta.content {
                     for task_metrics in m.tasks {
                         if let Some(task_key) = task_metrics.task_key {
@@ -262,5 +292,89 @@ impl ExecutionPlan for NetworkShuffleExec {
 
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.worker_connections.metrics.clone_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion::physical_plan::repartition::RepartitionExec;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_optimized_mode_sets_single_partition() -> datafusion::common::Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let part = Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 8);
+
+        let repartition = Arc::new(RepartitionExec::try_new(
+            Arc::new(EmptyExec::new(schema.clone())),
+            part.clone(),
+        )?);
+
+        let optimized = NetworkShuffleExec::try_new(
+            repartition.clone(),
+            Uuid::new_v4(),
+            1,
+            8,
+            3,
+            true,
+        )?;
+
+        assert_eq!(optimized.properties.partitioning.partition_count(), 1);
+        assert!(optimized.optimize_shuffle_partitioning);
+
+        let legacy = NetworkShuffleExec::try_new(
+            repartition.clone(),
+            Uuid::new_v4(),
+            1,
+            2,
+            3,
+            false,
+        )?;
+
+        assert_eq!(legacy.properties.partitioning.partition_count(), 8);
+        assert!(!legacy.optimize_shuffle_partitioning);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_optimized_mode_no_partition_inflation() -> datafusion::common::Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("b", DataType::Int32, false)]));
+        let part = Partitioning::Hash(vec![Arc::new(Column::new("b", 0))], 4);
+
+        let repartition = Arc::new(RepartitionExec::try_new(
+            Arc::new(EmptyExec::new(schema.clone())),
+            part.clone(),
+        )?);
+
+        let optimized = NetworkShuffleExec::try_new(
+            repartition.clone(),
+            Uuid::new_v4(),
+            1,
+            4,
+            2,
+            true,
+        )?;
+
+        let input_plan = optimized.input_stage.plan.as_ref().unwrap();
+        assert_eq!(input_plan.output_partitioning().partition_count(), 4);
+
+        let legacy = NetworkShuffleExec::try_new(
+            repartition,
+            Uuid::new_v4(),
+            1,
+            4,
+            2,
+            false,
+        )?;
+
+        let input_plan = legacy.input_stage.plan.as_ref().unwrap();
+        assert_eq!(input_plan.output_partitioning().partition_count(), 16);
+
+        Ok(())
     }
 }

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -203,17 +203,11 @@ impl DisplayAs for NetworkShuffleExec {
         let input_tasks = self.input_stage.tasks.len();
         let partitions = self.properties.partitioning.partition_count();
         let stage = self.input_stage.num;
-        if self.optimize_shuffle_partitioning {
-            write!(
-                f,
-                "[Stage {stage}] => NetworkShuffleExec: output_partitions={partitions}, input_tasks={input_tasks}, optimized=true",
-            )
-        } else {
-            write!(
-                f,
-                "[Stage {stage}] => NetworkShuffleExec: output_partitions={partitions}, input_tasks={input_tasks}",
-            )
-        }
+        let optimized = self.optimize_shuffle_partitioning;
+        write!(
+            f,
+            "[Stage {stage}] => NetworkShuffleExec: output_partitions={partitions}, input_tasks={input_tasks}, optimized={optimized}",
+        )
     }
 }
 

--- a/src/execution_plans/network_shuffle.rs
+++ b/src/execution_plans/network_shuffle.rs
@@ -203,10 +203,17 @@ impl DisplayAs for NetworkShuffleExec {
         let input_tasks = self.input_stage.tasks.len();
         let partitions = self.properties.partitioning.partition_count();
         let stage = self.input_stage.num;
-        write!(
-            f,
-            "[Stage {stage}] => NetworkShuffleExec: output_partitions={partitions}, input_tasks={input_tasks}",
-        )
+        if self.optimize_shuffle_partitioning {
+            write!(
+                f,
+                "[Stage {stage}] => NetworkShuffleExec: output_partitions={partitions}, input_tasks={input_tasks}, optimized=true",
+            )
+        } else {
+            write!(
+                f,
+                "[Stage {stage}] => NetworkShuffleExec: output_partitions={partitions}, input_tasks={input_tasks}",
+            )
+        }
     }
 }
 

--- a/src/protobuf/distributed_codec.rs
+++ b/src/protobuf/distributed_codec.rs
@@ -78,6 +78,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                 schema,
                 partitioning,
                 input_stage,
+                optimize_shuffle_partitioning,
             }) => {
                 let schema: Schema = schema
                     .as_ref()
@@ -96,6 +97,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     partitioning,
                     Arc::new(schema),
                     parse_stage_proto(input_stage, inputs)?,
+                    optimize_shuffle_partitioning,
                 )))
             }
             DistributedExecNode::NetworkCoalesceTasks(NetworkCoalesceExecProto {
@@ -237,6 +239,7 @@ impl PhysicalExtensionCodec for DistributedCodec {
                     &DistributedCodec {},
                 )?),
                 input_stage: Some(encode_stage_proto(node.input_stage())?),
+                optimize_shuffle_partitioning: node.optimize_shuffle_partitioning,
             };
 
             let wrapper = DistributedExecProto {
@@ -385,6 +388,8 @@ pub struct NetworkShuffleExecProto {
     partitioning: Option<protobuf::Partitioning>,
     #[prost(message, optional, tag = "3")]
     input_stage: Option<StageProto>,
+    #[prost(bool, tag = "4")]
+    optimize_shuffle_partitioning: bool,
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -415,6 +420,7 @@ fn new_network_hash_shuffle_exec(
     partitioning: Partitioning,
     schema: SchemaRef,
     input_stage: Stage,
+    optimize_shuffle_partitioning: bool,
 ) -> NetworkShuffleExec {
     NetworkShuffleExec {
         properties: PlanProperties::new(
@@ -426,7 +432,7 @@ fn new_network_hash_shuffle_exec(
         worker_connections: WorkerConnectionPool::new(input_stage.tasks.len()),
         input_stage,
         metrics_collection: Default::default(),
-        optimize_shuffle_partitioning: false,
+        optimize_shuffle_partitioning,
     }
 }
 
@@ -566,7 +572,7 @@ mod tests {
         let schema = schema_i32("a");
         let part = Partitioning::Hash(vec![Arc::new(Column::new("a", 0))], 4);
         let plan: Arc<dyn ExecutionPlan> =
-            Arc::new(new_network_hash_shuffle_exec(part, schema, dummy_stage()));
+            Arc::new(new_network_hash_shuffle_exec(part, schema, dummy_stage(), false));
 
         let mut buf = Vec::new();
         codec.try_encode(plan.clone(), &mut buf)?;
@@ -587,6 +593,7 @@ mod tests {
             Partitioning::UnknownPartitioning(1),
             schema,
             dummy_stage(),
+            false,
         ));
 
         let plan: Arc<dyn ExecutionPlan> = Arc::new(PartitionIsolatorExec::new(flight.clone(), 1));
@@ -610,11 +617,13 @@ mod tests {
             Partitioning::RoundRobinBatch(2),
             schema.clone(),
             dummy_stage(),
+            false,
         ));
         let right = Arc::new(new_network_hash_shuffle_exec(
             Partitioning::RoundRobinBatch(2),
             schema.clone(),
             dummy_stage(),
+            false,
         ));
 
         let union = UnionExec::try_new(vec![left.clone(), right.clone()])?;
@@ -639,6 +648,7 @@ mod tests {
             Partitioning::UnknownPartitioning(1),
             schema.clone(),
             dummy_stage(),
+            false,
         ));
 
         let sort_expr = PhysicalSortExpr {
@@ -744,11 +754,13 @@ mod tests {
             Partitioning::RoundRobinBatch(2),
             schema.clone(),
             dummy_stage(),
+            false,
         )) as Arc<dyn ExecutionPlan>;
         let right = Arc::new(new_network_hash_shuffle_exec(
             Partitioning::RoundRobinBatch(2),
             schema.clone(),
             dummy_stage(),
+            false,
         )) as Arc<dyn ExecutionPlan>;
 
         let plan: Arc<dyn ExecutionPlan> =

--- a/src/protobuf/distributed_codec.rs
+++ b/src/protobuf/distributed_codec.rs
@@ -426,6 +426,7 @@ fn new_network_hash_shuffle_exec(
         worker_connections: WorkerConnectionPool::new(input_stage.tasks.len()),
         input_stage,
         metrics_collection: Default::default(),
+        optimize_shuffle_partitioning: false,
     }
 }
 

--- a/src/test_utils/plans.rs
+++ b/src/test_utils/plans.rs
@@ -118,12 +118,27 @@ pub(crate) fn base_session_builder(
     num_workers: usize,
     broadcast_enabled: bool,
 ) -> SessionStateBuilder {
+    base_session_builder_with_shuffle_optimization(
+        target_partitions,
+        num_workers,
+        broadcast_enabled,
+        false,
+    )
+}
+
+pub(crate) fn base_session_builder_with_shuffle_optimization(
+    target_partitions: usize,
+    num_workers: usize,
+    broadcast_enabled: bool,
+    optimize_shuffle_partitioning: bool,
+) -> SessionStateBuilder {
     let mut config = SessionConfig::new()
         .with_target_partitions(target_partitions)
         .with_information_schema(true);
 
     let d_cfg = DistributedConfig {
         broadcast_joins: broadcast_enabled,
+        optimize_shuffle_partitioning,
         ..Default::default()
     };
     config.set_distributed_option_extension(d_cfg);


### PR DESCRIPTION
# optimize_shuffle_partitioning_ratio
## Workload Guide

## What the ratio controls

At each shuffle boundary, the planner applies a clamp formula to determine how many tasks
the downstream stage should have:

- **ratio >= 1.0**: `clamp(cardinality, p, ceil(p * ratio))`
  - Lifts small cardinality up to `p` (enabling optimized 1:1 mapping)
  - Caps large cardinality at `p * ratio` (limiting N×M fanout)
  - ratio=1 always produces exactly `p` tasks → fully optimized every boundary
  - ratio=2 allows up to `2p` tasks → moderate parallelism with controlled fanout
- **ratio < 1.0**: `cardinality.min(ceil(p * ratio))`
  - Scales task count below `p` — useful for reducing parallelism on light workloads

Where `p` is the `output_partitions` of the NetworkShuffleExec at the boundary (determined
by `target_partitions` session config), and `cardinality` is the inherited task count from
upstream stages, adjusted by cardinality-effect factors from reducing operations.

The `use_optimized` flag on `NetworkShuffleExec` is set per-boundary when `task_count == p`.
When optimized, each consumer task reads exactly one partition stream (1:1 mapping) instead
of reading all N upstream streams and filtering by hash.

---

## Ratio selection by workload type

### ratio=1 (default, fully optimized everywhere)

Best for:
- Uniform data distribution where parallelism is already well-matched to `target_partitions`
- Light or medium workloads where network coordination overhead is significant relative to compute
- Deep pipelines (5+ stages) — ratio=1 keeps stream counts flat at `p` per boundary,
  preventing compounding fanout across many stages
- Cases where you want predictable, low-overhead behavior as a baseline

What it does: every shuffle boundary becomes optimized (1:1 task-to-partition mapping).
Stream counts stay constant at `p` across all stages regardless of source cardinality.

### ratio=2–3 (moderate, recommended general-purpose default)

Best for:
- Mixed workloads: heavy source stages followed by cardinality-reducing aggregations
- Queries where the source stage benefits from full parallelism but downstream stages
  are cheaper because aggregation has already reduced the data volume
- Production environments where you want parallelism headroom without aggressive tuning
- Situations where data distribution is mostly uniform but occasionally uneven

What it does: source and early stages can run at up to 2–3× the partition count, preserving
parallelism for heavy compute. Once a cardinality-reducing operation appears (partial
aggregate, filter with high selectivity), subsequent stages naturally inherit smaller
task counts, making the high ratio less impactful downstream.

### ratio=4+ (high parallelism)

Best for:
- Massive, uniformly distributed data with few pipeline stages
- Workloads where every stage is compute-bound and data is evenly split across workers
- Clusters with many workers where you want to utilize all available parallelism

Avoid when:
- Pipeline has many stages — stream count compounds per boundary. With N=15 tasks and p=4
  partitions, each boundary has 60 streams. Across 5 stages this means each worker
  simultaneously maintains many gRPC connections, increasing memory pressure proportional
  to `record_batch_buffer_size × connections`.
- Source data is skewed — see section below.

---

## When ratio does not help: skewed data

The ratio controls how many consumers drain upstream tasks. It does not control how evenly
data is distributed across those upstream tasks.

If one upstream task processes 167× more data than another (as seen in EventStore queries
over 6-month time ranges, where certain months have 27M events and others have near-zero),
every consumer stage will exhibit HOL (head-of-line) blocking — consumers finish their light
tasks quickly but then sit idle waiting for the single heavy upstream task to complete.

This manifests in plans as:
- High `network_latency_sum` on NetworkShuffleExec consumers (e.g., 180s, 69s, 236s)
- `send_time` on the heavy source task orders of magnitude above the others
- `fetch_time` uniformly high across all downstream tasks (all waiting for the same bottleneck)

**Ratio cannot fix this.** More consumers just means more workers waiting on the same slow
upstream task. The solution is a bytes-based or rows-based task estimator at the source stage
that splits heavy time-range partitions into multiple tasks before the first shuffle boundary.

---

## Multi-stage cardinality propagation

In a pipeline with multiple stages, the ratio affects early stages most significantly.
Later stages self-correct because:

1. Cardinality-reducing operations (partial aggregates, filters) scale down the inherited
   task count via the `cardinality_task_count_factor` configuration.
2. Once the task count drops below `p`, ratio=1 behavior kicks in anyway (lifting back to `p`).
3. Final stages producing small output (e.g., `LIMIT 10000`, top-N window) end up with
   `p` tasks regardless of what happened upstream.

This means **ratio matters most for the first 1–2 heavy stages**. Tuning ratio for the
whole query is really tuning for the source-side parallelism. The rest of the pipeline
adjusts naturally.

Typical multi-stage behavior with ratio=2 (p=4, source cardinality=15):

```
Stage 1: 15 tasks  (source, cardinality=15)
Stage 2: 15 tasks  (join/filter, cardinality inherited)
Stage 3: 8 tasks   (clamp(15, 4, 8) = 8, partial aggregate)
Stage 4: 4 tasks   (cardinality reduced by aggregate, matches p → optimized)
Stage 5: 4 tasks   (final output, optimized 1:1)
```

With ratio=4:

```
Stage 1: 15 tasks  (source, cardinality=15)
Stage 2: 15 tasks  (join/filter, cardinality inherited)
Stage 3: 15 tasks  (clamp(15, 4, 16) = 15, fits within window)
Stage 4: 5 tasks   (cardinality partially reduced, slight reduction from aggregate)
Stage 5: 4 tasks   (optimized, 4==p)
```

---

## Quick reference

| Scenario | Recommended ratio |
|---|---|
| Uniform data, any pipeline depth | 1 |
| Uniform data, source is heavy compute | 2–3 |
| Massive uniform data, few stages, many workers | 4+ |
| Deep pipeline (5+ stages) | 1–2 |
| Skewed data (any case) | Fix source estimator; ratio won't help |
| Light analytic queries | 1 |
| Heavy joins followed by aggregation | 2–3 |
| Window functions with skewed partition keys | Fix partition key distribution |

---

## Relationship to N×M fanout

Original behavior without `optimize_shuffle_partitioning`: every boundary is N×M, where
N is the upstream task count and M is `output_partitions`. Each consumer reads N streams.

With optimization enabled:
- ratio=1: always 1×M (optimized). M total streams per consumer.
- ratio=r: up to r×M streams per consumer at boundaries where cardinality > p.
- ratio=∞: full N×M restored everywhere (equivalent to no optimization).

The ratio is therefore a continuous knob between fully optimized (low fanout, low overhead,
requires uniform data) and fully N×M (maximum parallelism, maximum stream count, tolerates
any distribution).

For most production workloads, ratio=2 represents a reasonable tradeoff: it preserves
optimized behavior for light-to-medium stages while allowing heavy stages to utilize
more parallelism than a strict 1:1 mapping would permit.
